### PR TITLE
Enhancement of docker mounting config volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ARG MIRROR=mirror.bit.edu.cn
 
 # Installing Hadoop
 ARG HADOOP_VERSION=2.7.4
-# COPY hadoop-${HADOOP_VERSION}.tar.gz .
 RUN set -x \
     && wget -q http://${MIRROR}/apache/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz \
     && tar -xzvf hadoop-${HADOOP_VERSION}.tar.gz -C /usr/local/ \
@@ -21,19 +20,8 @@ ENV HADOOP_HOME=/usr/local/hadoop
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop
 ENV YARN_CONF_DIR=$HADOOP_HOME/etc/hadoop
 
-# Installing Spark
-ARG SPARK_VERSION=2.2.1
-# COPY spark-${SPARK_VERSION}-bin-without-hadoop.tgz .
-RUN set -x \
-    && wget -q http://${MIRROR}/apache/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz \
-    && tar -xzvf spark-${SPARK_VERSION}-bin-without-hadoop.tgz -C /usr/local/ \
-    && mv /usr/local/spark-${SPARK_VERSION}-bin-without-hadoop /usr/local/spark
-ENV SPARK_HOME=/usr/local/spark
-ENV LD_LIBRARY_PATH=$HADOOP_HOME/lib/native/:$LD_LIBRARY_PATH
-
 # Installing Hive
 ARG HIVE_VERSION=1.2.2
-# COPY apache-hive-${HIVE_VERSION}-bin.tar.gz .
 RUN set -x \
     && wget -q http://${MIRROR}/apache/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz \
     && tar -xzvf apache-hive-${HIVE_VERSION}-bin.tar.gz -C /usr/local/ \
@@ -44,7 +32,6 @@ ENV HIVE_CONF=$HIVE_HOME/conf
 
 # Installing HBase
 ARG HBASE_VERSION=1.3.1
-# COPY hbase-${HBASE_VERSION}-bin.tar.gz .
 RUN set -x \
     && wget -q http://${MIRROR}/apache/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz \
     && tar -xzvf hbase-${HBASE_VERSION}-bin.tar.gz -C /usr/local/ \
@@ -53,7 +40,6 @@ ENV HBASE_HOME=/usr/local/hbase
 
 # Installing Kylin
 ARG KYLIN_VERSION=2.2.0
-# COPY apache-kylin-${KYLIN_VERSION}-bin-hbase1x.tar.gz .
 RUN set -x \
     && wget -q http://${MIRROR}/apache/kylin/apache-kylin-${KYLIN_VERSION}/apache-kylin-${KYLIN_VERSION}-bin-hbase1x.tar.gz \
     && tar -xzvf apache-kylin-${KYLIN_VERSION}-bin-hbase1x.tar.gz -C /usr/local/ \
@@ -61,16 +47,18 @@ RUN set -x \
 ENV KYLIN_HOME=/usr/local/kylin
 
 # Setting the PATH environment variable
-ENV PATH=$PATH:$JAVA_HOME/bin:$HADOOP_HOME/bin:$HADOOP_HOME/sbin:$SPARK_HOME/bin:$HIVE_HOME/bin:$HBASE_HOME/bin:$KYLIN_HOME/bin
+ENV PATH=$PATH:$JAVA_HOME/bin:$HADOOP_HOME/bin:$HADOOP_HOME/sbin:$HIVE_HOME/bin:$HBASE_HOME/bin:$KYLIN_HOME/bin
 
-COPY client-conf/core-site.xml $HADOOP_HOME/etc/hadoop/core-site.xml
-COPY client-conf/hdfs-site.xml $HADOOP_HOME/etc/hadoop/hdfs-site.xml
-COPY client-conf/mapred-site.xml $HADOOP_HOME/etc/hadoop/mapred-site.xml
-COPY client-conf/yarn-site.xml $HADOOP_HOME/etc/hadoop/yarn-site.xml
-COPY client-conf/hbase-site.xml $HBASE_HOME/conf/hbase-site.xml
-COPY client-conf/hdfs-site.xml $HBASE_HOME/conf/hdfs-site.xml
-COPY client-conf/hive-site.xml $HIVE_HOME/conf/hive-site.xml
-COPY client-conf/mapred-site.xml $HIVE_HOME/conf/mapred-site.xml
+COPY client-conf /root/client-conf
+RUN set -x \
+    && ln -sf /root/client-conf/core-site.xml $HADOOP_HOME/etc/hadoop/core-site.xml \
+    && ln -sf /root/client-conf/hdfs-site.xml $HADOOP_HOME/etc/hadoop/hdfs-site.xml \
+    && ln -sf /root/client-conf/mapred-site.xml $HADOOP_HOME/etc/hadoop/mapred-site.xml \
+    && ln -sf /root/client-conf/yarn-site.xml $HADOOP_HOME/etc/hadoop/yarn-site.xml \
+    && ln -sf /root/client-conf/hbase-site.xml $HBASE_HOME/conf/hbase-site.xml \
+    && ln -sf /root/client-conf/hdfs-site.xml $HBASE_HOME/conf/hdfs-site.xml \
+    && ln -sf /root/client-conf/hive-site.xml $HIVE_HOME/conf/hive-site.xml \
+    && ln -sf /root/client-conf/mapred-site.xml $HIVE_HOME/conf/mapred-site.xml
 
 # Cleanup
 RUN rm -rf /tmp/*
@@ -79,5 +67,7 @@ WORKDIR /root
 EXPOSE 7070
 
 VOLUME /usr/local/kylin/logs
+VOLUME /usr/local/kylin/conf
+VOLUME /root/client-conf
 
 ENTRYPOINT ["sh", "-c", "/usr/local/kylin/bin/kylin.sh start; bash"]

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,18 @@ exec:
 	docker exec -it kylin bash
 
 run:
-	docker run -itd --name kylin -p 7070:7070 -v `pwd`/logs:/usr/local/kylin/logs --add-host="MASTER-NODE-HOSTNAME:10.1.2.48" --add-host="sandbox.hortonworks.com:10.1.2.48" kylin:2.2.0
+	docker run -itd --name kylin \
+	-p 7070:7070 \
+	-v `pwd`/logs:/usr/local/kylin/logs \
+	--add-host="MASTER-NODE-HOSTNAME:10.1.2.48" \
+	--add-host="sandbox.hortonworks.com:10.1.2.48" \
+	kyligence/kylin:2.2.0
 
 build:
-	docker build -t kylin:2.2.0 .
+	docker build -t kyligence/kylin:2.2.0 .
+
+push:
+	docker push kyligence/kylin:2.2.0
 
 clean:
 	docker stop kylin && docker rm kylin


### PR DESCRIPTION
Before PR some comments #4, #5 
```
Yongjie, thanks for this PR! a few comments on this update:

I see you installed Spark 2.2, actually Kylin package already has Spark embedded (with v2.1), so don't need to download and expand Spark;
In the docker run, is the "sandbox.hortonworks.com" required? As this image is common (not bind to HDP), can we remove the sandbox in add-host?
Could you please update the readme file to tell user how to use this docker image?
Thanks!
```

1. remove SPARK from dockerfile
2. add kylin config volume
3. "sandbox.hortonworks.com" is zookeeper broadcast hostname, is a option for zookeeper config.
4. I will update readme soon